### PR TITLE
Unify Styles Across Grammar, Vocabulary, Speaking, Listening, and Reading Pages

### DIFF
--- a/src/pages/aurora-site/grammar-content.jsx
+++ b/src/pages/aurora-site/grammar-content.jsx
@@ -1,99 +1,75 @@
 import React from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/layout/ui/card";
-import { Progress } from "@/components/layout/ui/progress";
-import { Book, CheckCircle, Lock } from "lucide-react";
-import { Link } from "react-router-dom";
+import { FileText, CheckCircle, Lock } from "lucide-react";
 
 const GrammarPage = () => {
   const grammarTopics = [
-    { title: "Present Simple", progress: 100, unlocked: true },
-    { title: "Present Continuous", progress: 75, unlocked: true },
-    { title: "Articles (A/An/The)", progress: 30, unlocked: true },
-    { title: "Plural Nouns", progress: 0, unlocked: true },
-    { title: "Basic Pronouns", progress: 0, unlocked: false },
-    { title: "Subject-Verb Agreement", progress: 0, unlocked: false },
-    { title: "Possessive Adjectives", progress: 0, unlocked: false },
-    { title: "Prepositions of Place", progress: 0, unlocked: false },
+    { id: "present-simple", title: "Present Simple", progress: 100, unlocked: true },
+    { id: "present-continuous", title: "Present Continuous", progress: 75, unlocked: true },
+    { id: "articles", title: "Articles (A/An/The)", progress: 30, unlocked: true },
+    { id: "plural-nouns", title: "Plural Nouns", progress: 0, unlocked: true },
+    { id: "basic-pronouns", title: "Basic Pronouns", progress: 0, unlocked: false },
+    { id: "subject-verb", title: "Subject-Verb Agreement", progress: 0, unlocked: false },
+    { id: "possessive-adj", title: "Possessive Adjectives", progress: 0, unlocked: false },
+    { id: "prepositions", title: "Prepositions of Place", progress: 0, unlocked: false },
   ];
 
   return (
-<div className="min-h-screen bg-transparent text-gray-900 p-6">
-      <div className="max-w-4xl mx-auto">
-        <div className="mb-8">
+    <div className="min-h-screen bg-[#111827] text-neutral-1 p-6">
+      <div className="max-w-3xl mx-auto">
+        <div className="mb-8 text-center">
           <h1 className="text-3xl font-bold mb-2">Grammar</h1>
-          <p className="text-gray-400">
+          <p className="text-neutral-2">
             Master the building blocks of language through structured lessons
             and exercises
           </p>
         </div>
 
-        <div className="grid gap-4 mb-8">
-          {grammarTopics.map((topic, index) => (
-            <Card key={index} className="bg-gray-800 border-gray-700">
-              <CardHeader className="flex flex-row items-center justify-between">
-                <CardTitle className="flex items-center gap-3">
-                  <Book className="w-5 h-5 text-blue-400" />
-                  <span className="text-white">{topic.title}</span>
-                </CardTitle>
-                {topic.unlocked ? (
-                  <CheckCircle
-                    className={`w-5 h-5 ${
-                      topic.progress === 100
-                        ? "text-green-500"
-                        : "text-gray-500"
-                    }`}
-                  />
-                ) : (
-                  <Lock className="w-5 h-5 text-gray-500" />
-                )}
-              </CardHeader>
-              <CardContent>
-                <div className="flex items-center gap-4">
-                  <Progress
-                    value={topic.progress}
-                    className="flex-1 bg-white"
-                  />
-                  <span className="text-sm text-gray-400">
-                    {topic.progress}%
-                  </span>
+        <div className="space-y-3">
+          {grammarTopics.map((topic) => (
+            <div key={topic.id} className="bg-dark-blue-5 rounded-lg p-4 border-2 border-[#1f2937]">
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-md bg-dark-blue-4 flex items-center justify-center">
+                    <FileText className="w-5 h-5 text-light-blue-1" />
+                  </div>
+                  <span className="text-neutral-1 font-medium">{topic.title}</span>
                 </div>
-              </CardContent>
-            </Card>
-          ))}
-            <Card key={grammarTopics.length+1} className="bg-gray-800 border-gray-700">
-              <CardHeader className="flex flex-row items-center justify-between">
-                <CardTitle className="flex items-center gap-3">
-                  <Book className="w-5 h-5 text-blue-400" />
-                  <span className="text-white">Practice 1</span>
-                </CardTitle>
-                <Link to="/quiz" className="bg-blue-500 hover:text-white hover:bg-blue-700 text-white px-4 py-2 rounded-xl">Start</Link>
-              </CardHeader>
-            </Card>
-            <Card key={grammarTopics.length+1} className="bg-gray-800 border-gray-700">
-              <CardHeader className="flex flex-row items-center justify-between">
-                <CardTitle className="flex items-center gap-3">
-                  <Book className="w-5 h-5 text-blue-400" />
-                  <span className="text-white">Practice 2</span>
-                </CardTitle>
-                <Link to="/practice/sentence-builder" className="bg-blue-500 hover:text-white hover:bg-blue-700 text-white px-4 py-2 rounded-xl">Start</Link>
-              </CardHeader>
-            </Card>
-        </div>
-
-        <Card className="bg-gray-800 border-gray-700">
-          <CardHeader>
-            <CardTitle className="text-white">Your Progress</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
-              <div className="flex justify-between items-center">
-                <span className="text-white">Total Progress</span>
-                <span className="text-blue-400">41%</span>
+                {topic.unlocked ? (
+                  <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
+                    topic.progress === 100
+                      ? "bg-green/20"
+                      : "bg-light-blue-1/20"
+                  }`}>
+                    <CheckCircle
+                      className={`w-5 h-5 ${
+                        topic.progress === 100
+                          ? "text-green"
+                          : "text-light-blue-1"
+                      }`}
+                    />
+                  </div>
+                ) : (
+                  <Lock className="w-5 h-5 text-neutral-4" />
+                )}
               </div>
-              <Progress value={41} className="w-full bg-white" />
+              <div className="h-2 w-full bg-neutral-1/10 rounded-full overflow-hidden">
+                <div 
+                  className={`h-full ${
+                    topic.progress === 100
+                      ? "bg-green"
+                      : topic.progress > 0
+                      ? "bg-light-blue-1"
+                      : ""
+                  }`}
+                  style={{ width: `${topic.progress}%` }}
+                />
+              </div>
+              <div className="text-right mt-1">
+                <span className="text-xs text-neutral-2">{topic.progress}%</span>
+              </div>
             </div>
-          </CardContent>
-        </Card>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/aurora-site/learning/listening-content.jsx
+++ b/src/pages/aurora-site/learning/listening-content.jsx
@@ -1,66 +1,66 @@
 import React from 'react';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/layout/ui/card';
-import { Progress } from '@/components/layout/ui/progress';
 import { Headphones, CheckCircle, Lock } from 'lucide-react';
 
 const ListeningPage = () => {
     const listeningTopics = [
-        { title: 'Basic Conversations', progress: 100, unlocked: true },
-        { title: 'Listening for Specific Information', progress: 90, unlocked: true },
-        { title: 'Understanding Accents', progress: 60, unlocked: true },
-        { title: 'News & Podcasts', progress: 40, unlocked: true },
-        { title: 'Movie Dialogues', progress: 0, unlocked: false },
-        { title: 'Lectures & Speeches', progress: 0, unlocked: false },
-        { title: 'Audio Stories', progress: 0, unlocked: false },
-        { title: 'Interactive Listening Activities', progress: 0, unlocked: false }
+        { id: 'basic-conversations', title: 'Basic Conversations', progress: 100, unlocked: true },
+        { id: 'everyday-dialogues', title: 'Everyday Dialogues', progress: 80, unlocked: true },
+        { id: 'podcasts', title: 'Podcasts', progress: 65, unlocked: true },
+        { id: 'news-broadcasts', title: 'News Broadcasts', progress: 45, unlocked: true },
+        { id: 'interviews', title: 'Interviews', progress: 20, unlocked: true },
+        { id: 'lectures', title: 'Lectures', progress: 0, unlocked: false },
+        { id: 'movies-tv', title: 'Movies & TV', progress: 0, unlocked: false },
+        { id: 'advanced-listening', title: 'Advanced Listening', progress: 0, unlocked: false }
     ];
 
     return (
-        <div className="min-h-screen bg-transparent text-gray-900 p-6">
-            <div className="max-w-4xl mx-auto">
-                <div className="mb-8">
+        <div className="min-h-screen bg-[#111827] text-neutral-1 p-6">
+            <div className="max-w-3xl mx-auto">
+                <div className="mb-8 text-center">
                     <h1 className="text-3xl font-bold mb-2">Listening Practice</h1>
-                    <p className="text-gray-400">Sharpen your listening skills through engaging audio content and exercises</p>
+                    <p className="text-neutral-2">Enhance your listening comprehension from simple dialogues to complex audio</p>
                 </div>
 
-                <div className="grid gap-4 mb-8">
-                    {listeningTopics.map((topic, index) => (
-                        <Card key={index} className="bg-gray-800 border-gray-700">
-                            <CardHeader className="flex flex-row items-center justify-between">
-                                <CardTitle className="flex items-center gap-3">
-                                    <Headphones className="w-5 h-5 text-purple-400" />
-                                    <span className='text-white'>{topic.title}</span>
-                                </CardTitle>
-                                {topic.unlocked ? (
-                                    <CheckCircle className={`w-5 h-5 ${topic.progress === 100 ? 'text-green-500' : 'text-gray-500'}`} />
-                                ) : (
-                                    <Lock className="w-5 h-5 text-gray-500" />
-                                )}
-                            </CardHeader>
-                            <CardContent>
-                                <div className="flex items-center gap-4">
-                                    <Progress value={topic.progress} className="flex-1 bg-white" />
-                                    <span className="text-sm text-gray-400">{topic.progress}%</span>
+                <div className="space-y-3">
+                    {listeningTopics.map((topic) => (
+                        <div key={topic.id} className="bg-dark-blue-5 rounded-lg p-4 border-2 border-[#1f2937]">
+                            <div className="flex items-center justify-between mb-2">
+                                <div className="flex items-center gap-3">
+                                    <div className="w-8 h-8 rounded-md bg-dark-blue-4 flex items-center justify-center">
+                                        <Headphones className="w-5 h-5 text-green-1" />
+                                    </div>
+                                    <span className="text-neutral-1 font-medium">{topic.title}</span>
                                 </div>
-                            </CardContent>
-                        </Card>
+                                {topic.unlocked ? (
+                                    <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
+                                        topic.progress === 100
+                                            ? "bg-green/20"
+                                            : "bg-green-1/20"
+                                    }`}>
+                                        <CheckCircle className={`w-5 h-5 ${topic.progress === 100 ? 'text-green' : 'text-green-1'}`} />
+                                    </div>
+                                ) : (
+                                    <Lock className="w-5 h-5 text-neutral-4" />
+                                )}
+                            </div>
+                            <div className="h-2 w-full bg-neutral-1/10 rounded-full overflow-hidden">
+                                <div 
+                                    className={`h-full ${
+                                        topic.progress === 100
+                                            ? "bg-green"
+                                            : topic.progress > 0
+                                            ? "bg-green-1"
+                                            : ""
+                                    }`}
+                                    style={{ width: `${topic.progress}%` }}
+                                />
+                            </div>
+                            <div className="text-right mt-1">
+                                <span className="text-xs text-neutral-2">{topic.progress}%</span>
+                            </div>
+                        </div>
                     ))}
                 </div>
-
-                <Card className="bg-gray-800 border-gray-700">
-                    <CardHeader>
-                        <CardTitle className='text-white'>Your Progress</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="space-y-2">
-                            <div className="flex justify-between items-center">
-                                <span className='text-white'>Total Progress</span>
-                                <span className="text-purple-400">48%</span>
-                            </div>
-                            <Progress value={48} className="w-full bg-white" />
-                        </div>
-                    </CardContent>
-                </Card>
             </div>
         </div>
     );

--- a/src/pages/aurora-site/learning/reading-content.jsx
+++ b/src/pages/aurora-site/learning/reading-content.jsx
@@ -1,66 +1,66 @@
 import React from 'react';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/layout/ui/card';
-import { Progress } from '@/components/layout/ui/progress';
 import { BookOpen, CheckCircle, Lock } from 'lucide-react';
 
 const ReadingPage = () => {
     const readingTopics = [
-        { title: 'Short Stories', progress: 100, unlocked: true },
-        { title: 'Articles & Blogs', progress: 85, unlocked: true },
-        { title: 'Comprehension Exercises', progress: 70, unlocked: true },
-        { title: 'Summarizing Texts', progress: 50, unlocked: true },
-        { title: 'Identifying Key Points', progress: 0, unlocked: false },
-        { title: 'Advanced Passages', progress: 0, unlocked: false },
-        { title: 'Critical Reading Skills', progress: 0, unlocked: false },
-        { title: 'Skimming & Scanning', progress: 0, unlocked: false }
+        { id: 'vocabulary-building', title: 'Vocabulary Building', progress: 100, unlocked: true },
+        { id: 'short-texts', title: 'Short Texts', progress: 95, unlocked: true },
+        { id: 'comprehension', title: 'Reading Comprehension', progress: 70, unlocked: true },
+        { id: 'articles', title: 'Articles & Essays', progress: 45, unlocked: true },
+        { id: 'literature', title: 'Literature', progress: 15, unlocked: true },
+        { id: 'technical-reading', title: 'Technical Reading', progress: 0, unlocked: false },
+        { id: 'critical-analysis', title: 'Critical Analysis', progress: 0, unlocked: false },
+        { id: 'research-papers', title: 'Research Papers', progress: 0, unlocked: false }
     ];
 
     return (
-<div className="min-h-screen bg-transparent text-gray-900 p-6">
-            <div className="max-w-4xl mx-auto">
-                <div className="mb-8">
+        <div className="min-h-screen bg-[#111827] text-neutral-1 p-6">
+            <div className="max-w-3xl mx-auto">
+                <div className="mb-8 text-center">
                     <h1 className="text-3xl font-bold mb-2">Reading Practice</h1>
-                    <p className="text-gray-400">Boost your reading comprehension with engaging texts and exercises</p>
+                    <p className="text-neutral-2">Build your reading skills from basic texts to complex literature</p>
                 </div>
 
-                <div className="grid gap-4 mb-8">
-                    {readingTopics.map((topic, index) => (
-                        <Card key={index} className="bg-gray-800 border-gray-700">
-                            <CardHeader className="flex flex-row items-center justify-between">
-                                <CardTitle className="flex items-center gap-3">
-                                    <BookOpen className="w-5 h-5 text-green-400" />
-                                    <span className='text-white'>{topic.title}</span>
-                                </CardTitle>
-                                {topic.unlocked ? (
-                                    <CheckCircle className={`w-5 h-5 ${topic.progress === 100 ? 'text-green-500' : 'text-gray-500'}`} />
-                                ) : (
-                                    <Lock className="w-5 h-5 text-gray-500" />
-                                )}
-                            </CardHeader>
-                            <CardContent>
-                                <div className="flex items-center gap-4">
-                                    <Progress value={topic.progress} className="flex-1 bg-white" />
-                                    <span className="text-sm text-gray-400">{topic.progress}%</span>
+                <div className="space-y-3">
+                    {readingTopics.map((topic) => (
+                        <div key={topic.id} className="bg-dark-blue-5 rounded-lg p-4 border-2 border-[#1f2937]">
+                            <div className="flex items-center justify-between mb-2">
+                                <div className="flex items-center gap-3">
+                                    <div className="w-8 h-8 rounded-md bg-dark-blue-4 flex items-center justify-center">
+                                        <BookOpen className="w-5 h-5 text-green-1" />
+                                    </div>
+                                    <span className="text-neutral-1 font-medium">{topic.title}</span>
                                 </div>
-                            </CardContent>
-                        </Card>
+                                {topic.unlocked ? (
+                                    <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
+                                        topic.progress === 100
+                                            ? "bg-green/20"
+                                            : "bg-green-1/20"
+                                    }`}>
+                                        <CheckCircle className={`w-5 h-5 ${topic.progress === 100 ? 'text-green' : 'text-green-1'}`} />
+                                    </div>
+                                ) : (
+                                    <Lock className="w-5 h-5 text-neutral-4" />
+                                )}
+                            </div>
+                            <div className="h-2 w-full bg-neutral-1/10 rounded-full overflow-hidden">
+                                <div 
+                                    className={`h-full ${
+                                        topic.progress === 100
+                                            ? "bg-green"
+                                            : topic.progress > 0
+                                            ? "bg-green-1"
+                                            : ""
+                                    }`}
+                                    style={{ width: `${topic.progress}%` }}
+                                />
+                            </div>
+                            <div className="text-right mt-1">
+                                <span className="text-xs text-neutral-2">{topic.progress}%</span>
+                            </div>
+                        </div>
                     ))}
                 </div>
-
-                <Card className="bg-gray-800 border-gray-700">
-                    <CardHeader>
-                        <CardTitle className='text-white'>Your Progress</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="space-y-2">
-                            <div className="flex justify-between items-center">
-                                <span className='text-white'>Total Progress</span>
-                                <span className="text-green-400">56%</span>
-                            </div>
-                            <Progress value={56} className="w-full bg-white" />
-                        </div>
-                    </CardContent>
-                </Card>
             </div>
         </div>
     );

--- a/src/pages/aurora-site/learning/speaking-content.jsx
+++ b/src/pages/aurora-site/learning/speaking-content.jsx
@@ -1,83 +1,66 @@
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/layout/ui/card";
-import { Progress } from "@/components/layout/ui/progress";
-import { CheckCircle, Lock, Mic } from "lucide-react";
+import React from 'react';
+import { Mic, CheckCircle, Lock } from 'lucide-react';
 
 const SpeakingPage = () => {
   const speakingTopics = [
-    { title: "Introduction & Greetings", progress: 100, unlocked: true },
-    { title: "Talking About Daily Routines", progress: 80, unlocked: true },
-    { title: "Describing People & Places", progress: 50, unlocked: true },
-    { title: "Expressing Opinions", progress: 25, unlocked: true },
-    { title: "Debating Skills", progress: 0, unlocked: false },
-    { title: "Storytelling", progress: 0, unlocked: false },
-    { title: "Making Requests", progress: 0, unlocked: false },
-    { title: "Giving Presentations", progress: 0, unlocked: false },
+    { id: 'basic-pronunciation', title: 'Basic Pronunciation', progress: 100, unlocked: true },
+    { id: 'everyday-phrases', title: 'Everyday Phrases', progress: 85, unlocked: true },
+    { id: 'conversation-skills', title: 'Conversation Skills', progress: 60, unlocked: true },
+    { id: 'fluency-building', title: 'Fluency Building', progress: 40, unlocked: true },
+    { id: 'public-speaking', title: 'Public Speaking', progress: 0, unlocked: false },
+    { id: 'debate-discussion', title: 'Debate & Discussion', progress: 0, unlocked: false },
+    { id: 'presentations', title: 'Presentations', progress: 0, unlocked: false },
+    { id: 'accent-reduction', title: 'Accent Reduction', progress: 0, unlocked: false }
   ];
 
   return (
-    <div className="min-h-screen bg-transparent text-gray-900 p-6">
-      <div className="max-w-4xl mx-auto">
-        <div className="mb-8">
+    <div className="min-h-screen bg-[#111827] text-neutral-1 p-6">
+      <div className="max-w-3xl mx-auto">
+        <div className="mb-8 text-center">
           <h1 className="text-3xl font-bold mb-2">Speaking Practice</h1>
-          <p className="text-gray-400">
-            Develop your speaking skills with practical topics and exercises
-          </p>
+          <p className="text-neutral-2">Improve your speaking abilities from pronunciation to fluent conversation</p>
         </div>
 
-        <div className="grid gap-4 mb-8">
-          {speakingTopics.map((topic, index) => (
-<Card key={index} className="bg-gray-800 border-gray-700">
-              <CardHeader className="flex flex-row items-center justify-between">
-                <CardTitle className="flex items-center gap-3">
-                  <Mic className="w-5 h-5 text-red-400" />
-                  <span className="text-white">{topic.title}</span>
-                </CardTitle>
-                {topic.unlocked ? (
-                  <CheckCircle
-                    className={`w-5 h-5 ${
-                      topic.progress === 100
-                        ? "text-green-500"
-                        : "text-gray-500"
-                    }`}
-                  />
-                ) : (
-                  <Lock className="w-5 h-5 text-gray-500" />
-                )}
-              </CardHeader>
-              <CardContent>
-                <div className="flex items-center gap-4">
-                  <Progress
-                    value={topic.progress}
-                    className="flex-1 bg-white"
-                  />
-                  <span className="text-sm text-gray-400">
-                    {topic.progress}%
-                  </span>
+        <div className="space-y-3">
+          {speakingTopics.map((topic) => (
+            <div key={topic.id} className="bg-dark-blue-5 rounded-lg p-4 border-2 border-[#1f2937]">
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-md bg-dark-blue-4 flex items-center justify-center">
+                    <Mic className="w-5 h-5 text-orange-1" />
+                  </div>
+                  <span className="text-neutral-1 font-medium">{topic.title}</span>
                 </div>
-              </CardContent>
-            </Card>
+                {topic.unlocked ? (
+                  <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
+                    topic.progress === 100
+                      ? "bg-green/20"
+                      : "bg-orange-1/20"
+                  }`}>
+                    <CheckCircle className={`w-5 h-5 ${topic.progress === 100 ? 'text-green' : 'text-orange-1'}`} />
+                  </div>
+                ) : (
+                  <Lock className="w-5 h-5 text-neutral-4" />
+                )}
+              </div>
+              <div className="h-2 w-full bg-neutral-1/10 rounded-full overflow-hidden">
+                <div 
+                  className={`h-full ${
+                    topic.progress === 100
+                        ? "bg-green"
+                        : topic.progress > 0
+                        ? "bg-orange-1"
+                        : ""
+                  }`}
+                  style={{ width: `${topic.progress}%` }}
+                />
+              </div>
+              <div className="text-right mt-1">
+                <span className="text-xs text-neutral-2">{topic.progress}%</span>
+              </div>
+            </div>
           ))}
         </div>
-
-<Card className="bg-gray-800 border-gray-700">
-      <CardHeader>
-            <CardTitle className="text-white">Your Progress</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-2">
-              <div className="flex justify-between items-center">
-                <span className="text-white">Total Progress</span>
-                <span className="text-red-400">39%</span>
-              </div>
-              <Progress value={39} className="w-full bg-white" />
-            </div>
-          </CardContent>
-        </Card>
       </div>
     </div>
   );

--- a/src/pages/aurora-site/learning/vocabulary-content.jsx
+++ b/src/pages/aurora-site/learning/vocabulary-content.jsx
@@ -1,66 +1,66 @@
 import React from 'react';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/layout/ui/card';
-import { Progress } from '@/components/layout/ui/progress';
-import { BookOpen, CheckCircle, Lock } from 'lucide-react';
+import { FileText, CheckCircle, Lock } from 'lucide-react';
 
 const VocabularyPage = () => {
     const vocabTopics = [
-        { title: 'Synonyms', progress: 100, unlocked: true },
-        { title: 'Antonyms', progress: 85, unlocked: true },
-        { title: 'Phrasal Verbs', progress: 60, unlocked: true },
-        { title: 'Idioms & Expressions', progress: 20, unlocked: true },
-        { title: 'Word Formation', progress: 0, unlocked: false },
-        { title: 'Collocations', progress: 0, unlocked: false },
-        { title: 'Homophones', progress: 0, unlocked: false },
-        { title: 'Commonly Confused Words', progress: 0, unlocked: false }
+        { id: 'synonyms', title: 'Synonyms', progress: 100, unlocked: true },
+        { id: 'antonyms', title: 'Antonyms', progress: 85, unlocked: true },
+        { id: 'phrasal-verbs', title: 'Phrasal Verbs', progress: 60, unlocked: true },
+        { id: 'idioms', title: 'Idioms & Expressions', progress: 20, unlocked: true },
+        { id: 'word-formation', title: 'Word Formation', progress: 0, unlocked: false },
+        { id: 'collocations', title: 'Collocations', progress: 0, unlocked: false },
+        { id: 'homophones', title: 'Homophones', progress: 0, unlocked: false },
+        { id: 'confused-words', title: 'Commonly Confused Words', progress: 0, unlocked: false }
     ];
 
     return (
-<div className="min-h-screen bg-transparent text-gray-900 p-6">
-            <div className="max-w-4xl mx-auto">
-                <div className="mb-8">
+        <div className="min-h-screen bg-[#111827] text-neutral-1 p-6">
+            <div className="max-w-3xl mx-auto">
+                <div className="mb-8 text-center">
                     <h1 className="text-3xl font-bold mb-2">Vocabulary</h1>
-                    <p className="text-gray-400">Enhance your word power with engaging lessons and exercises</p>
+                    <p className="text-neutral-2">Enhance your word power with engaging lessons and exercises</p>
                 </div>
 
-                <div className="grid gap-4 mb-8">
-                    {vocabTopics.map((topic, index) => (
-                        <Card key={index} className="bg-gray-800 border-gray-700">
-                            <CardHeader className="flex flex-row items-center justify-between">
-                                <CardTitle className="flex items-center gap-3">
-                                    <BookOpen className="w-5 h-5 text-yellow-400" />
-                                    <span className='text-white'>{topic.title}</span>
-                                </CardTitle>
-                                {topic.unlocked ? (
-                                    <CheckCircle className={`w-5 h-5 ${topic.progress === 100 ? 'text-green-500' : 'text-gray-500'}`} />
-                                ) : (
-                                    <Lock className="w-5 h-5 text-gray-500" />
-                                )}
-                            </CardHeader>
-                            <CardContent>
-                                <div className="flex items-center gap-4">
-                                    <Progress value={topic.progress} className="flex-1 bg-white" />
-                                    <span className="text-sm text-gray-400">{topic.progress}%</span>
+                <div className="space-y-3">
+                    {vocabTopics.map((topic) => (
+                        <div key={topic.id} className="bg-dark-blue-5 rounded-lg p-4 border-2 border-[#1f2937]">
+                            <div className="flex items-center justify-between mb-2">
+                                <div className="flex items-center gap-3">
+                                    <div className="w-8 h-8 rounded-md bg-dark-blue-4 flex items-center justify-center">
+                                        <FileText className="w-5 h-5 text-light-blue-1" />
+                                    </div>
+                                    <span className="text-neutral-1 font-medium">{topic.title}</span>
                                 </div>
-                            </CardContent>
-                        </Card>
+                                {topic.unlocked ? (
+                                    <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
+                                        topic.progress === 100
+                                            ? "bg-green/20"
+                                            : "bg-light-blue-1/20"
+                                    }`}>
+                                        <CheckCircle className={`w-5 h-5 ${topic.progress === 100 ? 'text-green' : 'text-light-blue-1'}`} />
+                                    </div>
+                                ) : (
+                                    <Lock className="w-5 h-5 text-neutral-4" />
+                                )}
+                            </div>
+                            <div className="h-2 w-full bg-neutral-1/10 rounded-full overflow-hidden">
+                                <div 
+                                    className={`h-full ${
+                                        topic.progress === 100
+                                            ? "bg-green"
+                                            : topic.progress > 0
+                                            ? "bg-light-blue-1"
+                                            : ""
+                                    }`}
+                                    style={{ width: `${topic.progress}%` }}
+                                />
+                            </div>
+                            <div className="text-right mt-1">
+                                <span className="text-xs text-neutral-2">{topic.progress}%</span>
+                            </div>
+                        </div>
                     ))}
                 </div>
-
-                <Card className="bg-gray-800 border-gray-700">
-                    <CardHeader>
-                        <CardTitle className='text-white'>Your Progress</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="space-y-2">
-                            <div className="flex justify-between items-center">
-                                <span className='text-white'>Total Progress</span>
-                                <span className="text-yellow-400">41%</span>
-                            </div>
-                            <Progress value={41} className="w-full bg-white" />
-                        </div>
-                    </CardContent>
-                </Card>
             </div>
         </div>
     );


### PR DESCRIPTION
# 🚀 Pull Request

## Description
Unify Styles Across Grammar, Vocabulary, Speaking, Listening, and Reading Pages

## Related Issue
- [x] Closes #156 

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactoring
- [ ] 📚 Documentation update
- [ ] 🧪 Test update
- [ ] 🔒 Security fix
- [ ] 🧹 Chore

## Proof of Completion

https://github.com/user-attachments/assets/76af01b6-7e33-4997-a3e6-359a4a8d1de3

## Checklist
<!-- Mark items with an "x" when completed -->
- [ ] ✅ My code follows the project's coding standards
- [ ] 📝 I have updated the documentation as needed
- [ ] 🧪 I have added tests that prove my fix/feature works
- [ ] 🔄 I have rebased my branch with the latest main/develop
- [ ] 👀 I have performed a self-review of my own code

## Additional Notes
<!-- Add any other information about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all grammar, listening, reading, speaking, and vocabulary topic pages to use a new dark-themed, vertically stacked layout with custom-styled progress bars and icons.
  - Simplified UI by removing card-based layouts and external progress components, replacing them with div-based structures and Tailwind CSS styling.
  - Improved topic lists with unique identifiers and updated content, progress indicators, and iconography.
  - Removed summary and practice cards from all affected pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->