### PR TITLE
fix: prevent infinite loop in idiom challenge question loading

### DIFF
--- a/src/components/practices/funny_practices/idiom-challenge.jsx
+++ b/src/components/practices/funny_practices/idiom-challenge.jsx
@@ -82,19 +82,18 @@ const IdiomChallenge = () => {
         throw new Error("No valid questions available for this level.");
       }
 
-      // Randomize questions and ensure we have 10 unique questions
-      let result = [];
-      while (result.length < 10) {
-        const shuffled = [...formattedQuestions].sort(() => Math.random() - 0.5);
-        for (const q of shuffled) {
-          if (result.length === 0 || result[result.length - 1].idiom !== q.idiom) {
-            result.push(q);
-          }
-          if (result.length === 10) break;
-        }
+      // Get unique questions by idiom
+      const uniqueQuestions = Array.from(new Map(formattedQuestions.map((q) => [q.idiom, q])).values());
+
+      if (uniqueQuestions.length < 1) {
+        throw new Error(`Not enough unique questions available for level ${level}. Please add more questions.`);
       }
 
-      setQuestions(result);
+      // Randomize and select up to 10 questions
+      const shuffled = [...uniqueQuestions].sort(() => Math.random() - 0.5);
+      const selectedQuestions = shuffled.slice(0, Math.min(10, shuffled.length));
+
+      setQuestions(selectedQuestions);
       setCurrentQuestion(0);
       setSelectedAnswer(null);
       setIsCorrect(null);
@@ -102,6 +101,7 @@ const IdiomChallenge = () => {
       setCorrectAnswers(0);
     } catch (err) {
       setError(err.message || "An error occurred while fetching questions. Please try again.");
+      setQuestions([]);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
# 🚀 Pull Request

## Description
<!-- Provide a clear and concise description of the changes made in this PR -->
Fixes unresponsive behavior in idiom challenge component when loading questions.

## Related Issue
<!-- Add reference to the issue this PR addresses -->
Closes #[issue-number]

## Changes
- Removed infinite loop in question randomization
- Added efficient unique question selection using Map
- Improved error handling for empty question sets
- Added minimum question threshold (1 question)


## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Refactoring
- [ ] 📚 Documentation update
- [ ] 🧪 Test update
- [ ] 🔒 Security fix
- [ ] 🧹 Chore

## Proof of Completion
<!-- Provide evidence that the issue has been addressed properly -->
<!-- This could include screenshots, logs, or other relevant documentation -->

## Checklist
<!-- Mark items with an "x" when completed -->
- [ ] ✅ My code follows the project's coding standards
- [ ] 📝 I have updated the documentation as needed
- [ ] 🧪 I have added tests that prove my fix/feature works
- [ ] 🔄 I have rebased my branch with the latest main/develop
- [ ] 👀 I have performed a self-review of my own code

## Additional Notes
<!-- Add any other information about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the selection of idiom challenge questions to ensure greater variety and uniqueness in each session.
  - Enhanced error handling to clear questions if an error occurs during question selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->