### PR TITLE
feat: implement read_admin and read_deployer functions in transactions contract

### DIFF
--- a/blockchain/contracts/transactions/src/admin.rs
+++ b/blockchain/contracts/transactions/src/admin.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{Address, Env, Map};
-use crate::datatype::ADMINS;
+use crate::datatype::{ADMINS, DEPLOYER};
 use crate::interfaces::AdminInterface;
 
 pub struct AdminImpl;
@@ -7,6 +7,8 @@ pub struct AdminImpl;
 impl AdminInterface for AdminImpl {
     fn initialize(env: Env, admin: Address) {
         admin.require_auth();
+        
+        env.storage().instance().set(&DEPLOYER, &admin);
         
         let mut admins: Map<Address, bool> = Map::new(&env);
         admins.set(admin, true);
@@ -46,5 +48,19 @@ impl AdminInterface for AdminImpl {
             .unwrap_or(Map::new(&env));
         
         admins.get(address).unwrap_or(false)
+    }
+    
+    fn read_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DEPLOYER)
+            .expect("Contract not initialized")
+    }
+    
+    fn read_deployer(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DEPLOYER)
+            .expect("Contract not initialized")
     }
 } 

--- a/blockchain/contracts/transactions/src/datatype.rs
+++ b/blockchain/contracts/transactions/src/datatype.rs
@@ -12,6 +12,7 @@ pub const TRANSACTIONS_RECEIVED: &str = "transactions_received";
 pub const OUTGOING_TRANSACTIONS: &str = "outgoing_transactions";
 pub const USERS_POINTS: &str = "users_points";
 pub const ADMINS: &str = "admins";
+pub const DEPLOYER: &str = "deployer";
 pub const TOTAL_TRANSACTIONS: &str = "total_transactions";
 pub const TOTAL_CASH_OUTFLOWS: &str = "total_cash_outflows";
 pub const TOTAL_CASH_INFLOWS: &str = "total_cash_inflows";

--- a/blockchain/contracts/transactions/src/interfaces.rs
+++ b/blockchain/contracts/transactions/src/interfaces.rs
@@ -6,6 +6,8 @@ pub trait AdminInterface {
     fn add_admin(env: Env, caller: Address, new_admin: Address);
     fn only_admins(env: &Env, address: &Address) -> bool;
     fn is_admin(env: Env, address: Address) -> bool;
+    fn read_admin(env: Env) -> Address;
+    fn read_deployer(env: Env) -> Address;
 }
 
 pub trait TransactionInterface {

--- a/blockchain/contracts/transactions/src/lib.rs
+++ b/blockchain/contracts/transactions/src/lib.rs
@@ -48,6 +48,14 @@ impl Transactions {
         AdminImpl::is_admin(env, address)
     }
     
+    pub fn read_admin(env: Env) -> Address {
+        AdminImpl::read_admin(env)
+    }
+    
+    pub fn read_deployer(env: Env) -> Address {
+        AdminImpl::read_deployer(env)
+    }
+    
     // Transaction functions
     pub fn add_transaction_received(env: Env, caller: Address, address: Address, amount: i128) {
         TransactionImpl::add_transaction_received(env, caller, address, amount);


### PR DESCRIPTION
# 🚀 Pull Request

## Description

implement read_admin and read_deployer functions in transactions contract

- Add DEPLOYER storage key to datatype.rs
- Add read_admin and read_deployer functions to AdminInterface
- Update initialize function to store deployer address separately
- Implement read_admin and read_deployer functions in AdminImpl
- Add public read_admin and read_deployer functions to main contract
- Add comprehensive tests for new read functions

All tests passing: 4/4 tests in transactions contract

## Related Issue
<!-- Add reference to the issue this PR addresses -->
- [x] Closes #224 

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactoring
- [ ] 📚 Documentation update
- [ ] 🧪 Test update
- [ ] 🔒 Security fix
- [ ] 🧹 Chore

## Proof of Completion

<img width="1028" alt="Screenshot 2025-07-03 at 2 35 33 PM" src="https://github.com/user-attachments/assets/c8b25b83-8c0d-4e97-b558-04aa8d8975bf" />


## Checklist
<!-- Mark items with an "x" when completed -->
- [ ] ✅ My code follows the project's coding standards
- [ ] 📝 I have updated the documentation as needed
- [ ] 🧪 I have added tests that prove my fix/feature works
- [ ] 🔄 I have rebased my branch with the latest main/develop
- [ ] 👀 I have performed a self-review of my own code

## Additional Notes
<!-- Add any other information about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve the current admin and deployer addresses from the contract.

* **Tests**
  * Introduced tests to verify correct retrieval of admin and deployer addresses, as well as proper error handling when the contract is uninitialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->