### PR TITLE
[FEAT] Modify the word-matching file for support the api from the backend

### DIFF
--- a/src/components/Games/word-matching/game-board.jsx
+++ b/src/components/Games/word-matching/game-board.jsx
@@ -1,32 +1,54 @@
-import React, { useState, useEffect } from 'react';
-import { WORD_PAIRS, GAME_SETTINGS } from './mock-data-word-matching/word-matching';
-import Card from '@/components/games/word-matching/Card';
-import ScoreDisplay from './score-display';
+import { useState, useEffect } from "react";
+import { questionsApi } from "@/services/questionsApi";
+import {
+  GAME_SETTINGS,
+  DIFFICULTY_SETTINGS,
+  WORD_PAIRS,
+} from "./mock-data-word-matching/word-matching";
+import Card from "@/components/Games/word-matching/Card";
+import ScoreDisplay from "./score-display";
 
-const GameBoard = ({ difficulty, settings, onGameOver, onScoreUpdate }) => {
+const levelToDifficulty = {
+  A1: "Medium", // 8 pairs, 40s
+  A2: "Medium", // 8 pairs, 40s
+  B1: "Hard", // 12 pairs, 30s
+  B2: "Hard", // 12 pairs, 30s
+  C1: "Expert", // 16 pairs, 20s
+  C2: "Master", // 20 pairs, 15s
+};
+const getDifficultySettings = (level) => {
+  const difficulty = levelToDifficulty[level] || "Medium";
+  return DIFFICULTY_SETTINGS[difficulty];
+};
+
+const GameBoard = ({ selectedLevel, onGameOver, onScoreUpdate }) => {
   const [cards, setCards] = useState([]);
   const [flippedCards, setFlippedCards] = useState([]);
   const [matchedPairs, setMatchedPairs] = useState([]);
-  const [timeLeft, setTimeLeft] = useState(settings.time);
+  const [timeLeft, setTimeLeft] = useState(120);
   const [score, setScore] = useState(0);
+  const [wordPairs, setWordPairs] = useState([]);
+
+  const settings = getDifficultySettings(selectedLevel);
 
   // Initialize game with shuffled cards
   const initializeGame = () => {
     // Select random pairs based on difficulty
-    const selectedPairs = [...WORD_PAIRS]
+    const selectedPairs = [...wordPairs]
       .sort(() => Math.random() - 0.5)
       .slice(0, settings.pairs);
 
     // Create cards for both English and Spanish words
-    const gameCards = selectedPairs.flatMap(pair => [
-      { id: pair.id, word: pair.wordEn, language: 'en' },
-      { id: pair.id, word: pair.wordEs, language: 'es' }
-    ])
-    .sort(() => Math.random() - 0.5)
-    .map((card, index) => ({
-      ...card,
-      uniqueId: index,
-    }));
+    const gameCards = selectedPairs
+      .flatMap((pair) => [
+        { id: pair.id, word: pair.wordEn, language: "en" },
+        { id: pair.id, word: pair.wordEs, language: "es" },
+      ])
+      .sort(() => Math.random() - 0.5)
+      .map((card, index) => ({
+        ...card,
+        uniqueId: index,
+      }));
 
     setCards(gameCards);
     setFlippedCards([]);
@@ -39,9 +61,10 @@ const GameBoard = ({ difficulty, settings, onGameOver, onScoreUpdate }) => {
   const handleCardClick = (index) => {
     // Prevent clicking if two cards are already flipped
     if (flippedCards.length === 2) return;
-    
+
     // Prevent clicking already matched or flipped cards
-    if (matchedPairs.includes(cards[index].id) || flippedCards.includes(index)) return;
+    if (matchedPairs.includes(cards[index].id) || flippedCards.includes(index))
+      return;
 
     const newFlippedCards = [...flippedCards, index];
     setFlippedCards(newFlippedCards);
@@ -56,15 +79,17 @@ const GameBoard = ({ difficulty, settings, onGameOver, onScoreUpdate }) => {
         // Match found
         setMatchedPairs([...matchedPairs, firstCard.id]);
         setFlippedCards([]);
-        
+
         // Base points for match
         const newScore = score + GAME_SETTINGS.POINTS.MATCH;
         setScore(newScore);
         onScoreUpdate(newScore);
-        
+
         // Check for combo bonus
-        if (matchedPairs.length > 0 && 
-            (matchedPairs.length + 1) % GAME_SETTINGS.TIMING.COMBO_THRESHOLD === 0) {
+        if (
+          matchedPairs.length > 0 &&
+          (matchedPairs.length + 1) % GAME_SETTINGS.TIMING.COMBO_THRESHOLD === 0
+        ) {
           const bonusScore = newScore + GAME_SETTINGS.POINTS.COMBO_BONUS;
           setScore(bonusScore);
           onScoreUpdate(bonusScore);
@@ -78,10 +103,55 @@ const GameBoard = ({ difficulty, settings, onGameOver, onScoreUpdate }) => {
     }
   };
 
+  // Fetch questions and initialize game when level changes
+  useEffect(() => {
+    if (selectedLevel) {
+      const fetchQuestions = async () => {
+        try {
+          const response = await questionsApi.getAllQuestions({
+            englishLevel: selectedLevel,
+            type: "word-matching",
+            difficulty: levelToDifficulty[selectedLevel] || "Medium",
+          });
+
+          if (response.data && response.data.length > 0) {
+            // Transform API data to expected format
+            const transformedPairs = response.data.map((item) => {
+              const content = item.content || {};
+              return {
+                id: item.id,
+                wordEn: content.wordEn,
+                wordEs: content.wordEs,
+              };
+            });
+            setWordPairs(transformedPairs);
+          } else {
+            // Fallback to mock data if no API data
+            setWordPairs(WORD_PAIRS);
+          }
+        } catch (error) {
+          console.error("Error fetching questions:", error);
+          // Fallback to mock data on error
+          setWordPairs(WORD_PAIRS);
+        }
+      };
+
+      fetchQuestions();
+    }
+  }, [selectedLevel, settings.pairs]);
+
+  // Initialize game when wordPairs change
+  useEffect(() => {
+    if (wordPairs.length > 0) {
+      initializeGame();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wordPairs]);
+
   // Update timer effect to pass the final score
   useEffect(() => {
     const timer = setInterval(() => {
-      setTimeLeft(prev => {
+      setTimeLeft((prev) => {
         if (prev <= 1) {
           clearInterval(timer);
           onGameOver(score); // Pass the current score when game ends
@@ -98,19 +168,14 @@ const GameBoard = ({ difficulty, settings, onGameOver, onScoreUpdate }) => {
     }
 
     return () => clearInterval(timer);
-  }, [timeLeft, matchedPairs.length, score]); // Add score to dependencies
-
-  // Initialize game when difficulty changes
-  useEffect(() => {
-    initializeGame();
-  }, [difficulty]);
+  }, [timeLeft, matchedPairs.length, score, settings.pairs, onGameOver]);
 
   return (
     <div className="flex flex-col items-center gap-4 w-full max-w-7xl mx-auto">
       <ScoreDisplay score={score} timeLeft={timeLeft} />
       <div className="flex flex-col items-center gap-4 bg-white p-8 rounded-lg w-full">
         <div className="text-xl font-bold text-gray-900 mb-4">
-          Time Left: {timeLeft}s
+          Level {selectedLevel} - Time Left: {timeLeft}s
         </div>
         <div className="grid grid-cols-4 gap-4 w-full justify-items-center">
           {cards.map((card, index) => (

--- a/src/components/Games/word-matching/level-selector.jsx
+++ b/src/components/Games/word-matching/level-selector.jsx
@@ -1,0 +1,28 @@
+const englishLevels = [
+  { level: "A1", description: "Beginner" },
+  { level: "A2", description: "Elementary" },
+  { level: "B1", description: "Intermediate" },
+  { level: "B2", description: "Upper Intermediate" },
+  { level: "C1", description: "Advanced" },
+  { level: "C2", description: "Mastery" },
+];
+
+export default function LevelSelector({ onLevelSelect }) {
+  return (
+    <div className="max-w-md mx-auto mt-10 p-6 bg-white shadow-lg rounded-lg">
+      <h2 className="text-2xl font-bold text-center mb-6 text-black">Select Your English Level</h2>
+      <div className="grid grid-cols-2 gap-4">
+        {englishLevels.map(({ level, description }) => (
+          <button
+            key={level}
+            onClick={() => onLevelSelect(level)}
+            className="p-4 border border-gray-200 rounded-lg hover:bg-blue-50 transition-colors text-left"
+          >
+            <div className="font-bold text-blue-600">{level}</div>
+            <div className="text-sm text-gray-600">{description}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Games/word-matching/word-matching-game.jsx
+++ b/src/components/Games/word-matching/word-matching-game.jsx
@@ -1,17 +1,16 @@
-import React, { useState } from 'react';
-import DifficultySelector from './difficulty-selector';
+import { useState } from 'react';
+import LevelSelector from './level-selector';
 import GameBoard from './game-board';
 import GameOver from './game-over';
-import { DIFFICULTY_SETTINGS } from './mock-data-word-matching/word-matching';
 
 const WordMatchingGame = () => {
-  const [difficulty, setDifficulty] = useState('Medium');
+  const [selectedLevel, setSelectedLevel] = useState(null);
   const [score, setScore] = useState(0);
   const [gameStarted, setGameStarted] = useState(false);
   const [gameOver, setGameOver] = useState(false);
 
-  const handleGameStart = (selectedDifficulty) => {
-    setDifficulty(selectedDifficulty);
+  const handleLevelSelect = (level) => {
+    setSelectedLevel(level);
     setScore(0);
     setGameStarted(true);
     setGameOver(false);
@@ -23,20 +22,24 @@ const WordMatchingGame = () => {
     setGameStarted(false);
   };
 
+  const handlePlayAgain = () => {
+    if (selectedLevel) {
+      handleLevelSelect(selectedLevel);
+    }
+  };
+
   return (
     <div className="flex flex-col items-center p-4">
       {!gameStarted && !gameOver && (
-        <DifficultySelector 
-          onSelect={handleGameStart}
-          currentDifficulty={difficulty}
+        <LevelSelector 
+          onLevelSelect={handleLevelSelect}
         />
       )}
       
       {gameStarted && (
         <>
           <GameBoard
-            difficulty={difficulty}
-            settings={DIFFICULTY_SETTINGS[difficulty]}
+            selectedLevel={selectedLevel}
             onGameOver={handleGameOver}
             onScoreUpdate={setScore}
           />
@@ -46,7 +49,7 @@ const WordMatchingGame = () => {
       {gameOver && (
         <GameOver 
           score={score} 
-          onPlayAgain={() => handleGameStart(difficulty)}
+          onPlayAgain={handlePlayAgain}
         />
       )}
     </div>


### PR DESCRIPTION
# 🚀 Pull Request

## Description
Word Matching selection page and intergate backend api
### NOTE: Need implement word-matching questions for Backend

## Related Issue
Closes #272 

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactoring
- [ ] 📚 Documentation update
- [ ] 🧪 Test update
- [ ] 🔒 Security fix
- [ ] 🧹 Chore

## Proof of Completion
https://github.com/user-attachments/assets/feee8c34-1972-4316-a588-61169d02e40f

## Checklist
- [x] ✅ My code follows the project's coding standards
- [x] 📝 I have updated the documentation as needed
- [x] 🧪 I have added tests that prove my fix/feature works
- [x] 🔄 I have rebased my branch with the latest main/develop
- [x] 👀 I have performed a self-review of my own code



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choose your English level (A1–C2) before playing.
  * Game content and difficulty now adjust automatically based on the selected level.
  * Word pairs load dynamically; if unavailable, a built-in set is used.
  * Play Again restarts using your last selected level.
  * Header now shows “Level {selectedLevel}” alongside the countdown timer.
  * The game ends automatically when time runs out and reports your final score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->